### PR TITLE
chore: use Docker Hub user fty4 instead of taskmedia

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,8 +88,8 @@ jobs:
         tags: |
           ${{ steps.meta.outputs.tags }}
           ghcr.io/taskmedia/curl-jq:latest
-          taskmedia/curl-jq:main
-          taskmedia/curl-jq:latest
+          fty4/curl-jq:main
+          fty4/curl-jq:latest
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ This image will build every two weeks and push it to the ghcr.io registry.
 docker pull ghcr.io/taskmedia/curl-jq:main
 
 # Pull from Docker Hub
-docker pull taskmedia/curl-jq:main
+docker pull fty4/curl-jq:main
 ```


### PR DESCRIPTION
Docker deprecated free orgs - moving to personal account