### PR TITLE
fix(docker): linux/s390x not longer supported by curl image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,7 +85,6 @@ jobs:
           linux/amd64
           linux/arm64
           linux/ppc64le
-          linux/s390x
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Image not longer available and can not be build from curl image.

see failing check in #15