### PR TITLE
chore(Dockerfile): use equal sign for label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM curlimages/curl
 
 # Image annotations
 # see: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
-LABEL org.opencontainers.image.title curl-jq
-LABEL org.opencontainers.image.description image with curl and jq installed
-LABEL org.opencontainers.image.url https://github.com/taskmedia/curl-jq/pkgs/container/curl-jq
-LABEL org.opencontainers.image.source https://github.com/taskmedia/curl-jq/blob/main/Dockerfile
-LABEL org.opencontainers.image.vendor task.media
-LABEL org.opencontainers.image.licenses MIT
+LABEL org.opencontainers.image.title=curl-jq
+LABEL org.opencontainers.image.description="image with curl and jq installed"
+LABEL org.opencontainers.image.url=https://github.com/taskmedia/curl-jq/pkgs/container/curl-jq
+LABEL org.opencontainers.image.source=https://github.com/taskmedia/curl-jq/blob/main/Dockerfile
+LABEL org.opencontainers.image.vendor=task.media
+LABEL org.opencontainers.image.licenses=MIT
 
 USER root
 


### PR DESCRIPTION
get rid of LegacyKeyValueFormat warning