### PR TITLE
fix: replace deprecated cosign --tlog-upload=false with --signing-config

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,11 +103,12 @@ jobs:
     # https://github.com/sigstore/cosign
     - name: Sign the published Docker image
       if: ${{ github.event_name != 'pull_request' }}
-      env:
-        COSIGN_EXPERIMENTAL: "true"
       # This step uses the identity token to provision an ephemeral certificate
       # against the sigstore community Fulcio instance.
-      run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes --tlog-upload=false {}@${{ steps.build-and-push.outputs.digest }}
+      run: |
+        curl -s https://raw.githubusercontent.com/sigstore/root-signing/refs/heads/main/targets/signing_config.v0.2.json \
+          | jq 'del(.rekorTlogUrls)' > /tmp/signing_config.json
+        echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes --signing-config /tmp/signing_config.json {}@${{ steps.build-and-push.outputs.digest }}
 
     - name: Get repository name
       env:


### PR DESCRIPTION
## Problem

All three `taskmedia/curl-jq`, `kubectl-gpg-ncftp`, and `kubectl-yq` pipelines are failing today at the **Sign the published Docker image** step with exit code 123:

```
Error: --tlog-upload=false is not supported with --signing-config or --use-signing-config.
```

Root cause: `sigstore/cosign-installer` at the pinned SHA (`6f9f177...` = v4.1.2) installs **cosign v3.0.6**, which removed support for `--tlog-upload=false` as a standalone flag when a signing config is active (now the default in v3).

## Fix

Replace the broken one-liner with the approach cosign v3 requires — fetch the public sigstore signing config, strip the Rekor tlog URLs with `jq`, then pass it via `--signing-config`. This preserves the original intent: sign the image without uploading to the transparency log.

Also removes `COSIGN_EXPERIMENTAL: "true"` which is a no-op in cosign v3 (keyless signing is the default now).

## Note

The same fix applies to `kubectl-gpg-ncftp` and `kubectl-yq` — applying to `curl-jq` first for review.